### PR TITLE
TransactWriteItems implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ using AI-powered code generation tools like Amazon Q to streamline development.
 
 ## Features
 
-* **DynamoDB-like API:** `PutItem`, `UpdateItem`, `DeleteItem`, `GetItem`, `Query`.
+* **DynamoDB-like API:** `PutItem`, `UpdateItem`, `DeleteItem`, `GetItem`, `Query`, `TransactWriteItems`.
 * **RocksDB Storage:** Utilizing RocksDB for fast and reliable data storage.
 * **gRPC Interface:** Providing a high-performance gRPC API for client interactions.
 * **Efficient Data Serialization:** Leveraging gRPC's Protocol Buffers for efficient data serialization.
@@ -189,6 +189,5 @@ This project is licensed under the Apache 2.0 License. See the `LICENSE` file fo
 
 ## Future Work
 
-* Future features or improvements: global secondary indexes, enhanced consistency.
-* Add more DynamoDB API implementations: `TransactWriteItems`.
+* Future features or improvements: delete by partition, multi-tenancy, global secondary indexes.
 * Improve performance and scalability.

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -14,6 +14,8 @@ minikube dashboard
 Create RoxDB deployment and service:
 
 ```bash
+# change to kubernetes directory
+cd kubernetes
 # create the deployment and the service
 kubectl apply -f roxdb-deployment.yaml
 # check pods
@@ -22,6 +24,8 @@ kubectl get pods
 kubectl get services
 # describe the pod
 kubectl describe pod -l app=roxdb
+# view pod logs
+kubectl logs -l app=roxdb
 ```
 
 Get the URL to access RoxDB service:
@@ -33,8 +37,5 @@ minikube service roxdb --url
 Delete the deployment and service:
 
 ```bash
-# view pod logs
-kubectl logs -l app=roxdb
-# delete the deployment and service
 kubectl delete -f roxdb-deployment.yaml
 ```

--- a/src/main/java/com/github/lukaszbudnik/roxdb/grpc/ProtoUtils.java
+++ b/src/main/java/com/github/lukaszbudnik/roxdb/grpc/ProtoUtils.java
@@ -69,7 +69,7 @@ public class ProtoUtils {
     throw new IllegalArgumentException("Unsupported type: " + obj.getClass());
   }
 
-  public static Item itemToProto(com.github.lukaszbudnik.roxdb.rocksdb.Item item) {
+  public static Item itemModelToProto(com.github.lukaszbudnik.roxdb.rocksdb.Item item) {
     return Item.newBuilder()
         .setKey(
             Key.newBuilder()
@@ -78,5 +78,16 @@ public class ProtoUtils {
                 .build())
         .setAttributes(ProtoUtils.mapToStruct(item.attributes()))
         .build();
+  }
+
+  public static com.github.lukaszbudnik.roxdb.rocksdb.Item itemProtoToModel(Item item) {
+    return new com.github.lukaszbudnik.roxdb.rocksdb.Item(
+        new com.github.lukaszbudnik.roxdb.rocksdb.Key(
+            item.getKey().getPartitionKey(), item.getKey().getSortKey()),
+        ProtoUtils.structToMap(item.getAttributes()));
+  }
+
+  public static com.github.lukaszbudnik.roxdb.rocksdb.Key keyProtoToModel(Key key) {
+    return new com.github.lukaszbudnik.roxdb.rocksdb.Key(key.getPartitionKey(), key.getSortKey());
   }
 }

--- a/src/main/java/com/github/lukaszbudnik/roxdb/rocksdb/RoxDB.java
+++ b/src/main/java/com/github/lukaszbudnik/roxdb/rocksdb/RoxDB.java
@@ -2,19 +2,19 @@ package com.github.lukaszbudnik.roxdb.rocksdb;
 
 import java.util.List;
 import java.util.Optional;
+
+import org.rocksdb.ColumnFamilyHandle;
 import org.rocksdb.RocksDBException;
 
 public interface RoxDB extends AutoCloseable {
-  // PutItem operation
+  ColumnFamilyHandle getOrCreateColumnFamily(String tableName) throws RocksDBException;
+
   void putItem(String tableName, Item item) throws RocksDBException;
 
-  // UpdateItem operation
   void updateItem(String tableName, Item item) throws RocksDBException;
 
-  // GetItem operation
   Item getItem(String tableName, Key key) throws RocksDBException;
 
-  // Query operation
   List<Item> query(
       String tableName,
       String partitionKey,
@@ -22,6 +22,7 @@ public interface RoxDB extends AutoCloseable {
       Optional<String> sortKeyEnd)
       throws RocksDBException;
 
-  // Delete operation
   void deleteItem(String tableName, Key key) throws RocksDBException;
+
+  void executeTransaction(TransactionOperations transactionContext) throws RocksDBException;
 }

--- a/src/main/java/com/github/lukaszbudnik/roxdb/rocksdb/SerDeUtils.java
+++ b/src/main/java/com/github/lukaszbudnik/roxdb/rocksdb/SerDeUtils.java
@@ -1,0 +1,48 @@
+package com.github.lukaszbudnik.roxdb.rocksdb;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+import org.slf4j.Logger;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+public class SerDeUtils {
+  private static final Kryo kryo;
+  private static final Logger logger = org.slf4j.LoggerFactory.getLogger(SerDeUtils.class);
+
+  static {
+    kryo = new Kryo();
+    kryo.register(HashMap.class);
+  }
+
+  public static byte[] serializeKey(Item item) {
+    return item.key().toStorageKey().getBytes();
+  }
+
+  public static byte[] serializeAttributes(Item item) {
+    byte[] value = null;
+    try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        Output output = new Output(baos)) {
+      kryo.writeObject(output, item.attributes());
+      // needs explicit flush
+      output.flush();
+      value = baos.toByteArray();
+    } catch (IOException e) {
+      logger.error("Error serializing item: {}", item.key().toStorageKey(), e);
+      throw new RuntimeException(e);
+    }
+    return value;
+  }
+
+  public static Map<String, Object> deserializeAttributes(byte[] value) {
+    Map<String, Object> attributes = null;
+    try (Input input = new Input(value)) {
+      attributes = kryo.readObject(input, HashMap.class);
+    }
+    return attributes;
+  }
+}

--- a/src/main/java/com/github/lukaszbudnik/roxdb/rocksdb/TransactionContext.java
+++ b/src/main/java/com/github/lukaszbudnik/roxdb/rocksdb/TransactionContext.java
@@ -1,0 +1,70 @@
+package com.github.lukaszbudnik.roxdb.rocksdb;
+
+import org.rocksdb.ReadOptions;
+import org.rocksdb.RocksDBException;
+import org.rocksdb.Transaction;
+import org.slf4j.Logger;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class TransactionContext {
+  private final Logger logger = org.slf4j.LoggerFactory.getLogger(TransactionContext.class);
+  private final Transaction transaction;
+  private final RoxDB roxDB;
+
+  public TransactionContext(RoxDB roxDB, Transaction transaction) {
+    this.transaction = transaction;
+    this.roxDB = roxDB;
+  }
+
+  public void put(String tableName, Item item) throws RocksDBException {
+    byte[] key = SerDeUtils.serializeKey(item);
+    byte[] value = SerDeUtils.serializeAttributes(item);
+    transaction.put(roxDB.getOrCreateColumnFamily(tableName), key, value);
+    logger.debug("Transaction {} put: {}", transaction.getID(), item.key().toStorageKey());
+  }
+
+  public void update(String tableName, Item item) throws RocksDBException {
+    Item existingItem = get(tableName, item.key());
+
+    if (existingItem == null) {
+      // If item doesn't exist, perform a put operation
+      put(tableName, item);
+      return;
+    }
+
+    // Merge existing and new attributes
+    Map<String, Object> mergedAttributes = new HashMap<>(existingItem.attributes());
+    mergedAttributes.putAll(item.attributes());
+
+    // Create new item with merged attributes
+    Item updatedItem = new Item(item.key(), mergedAttributes);
+
+    put(tableName, updatedItem);
+  }
+
+  public void delete(String tableName, Key key) throws RocksDBException {
+    byte[] keyBytes = key.toStorageKey().getBytes();
+    transaction.delete(roxDB.getOrCreateColumnFamily(tableName), keyBytes);
+    logger.debug("Transaction {} delete: {}", transaction.getID(), key.toStorageKey());
+  }
+
+  // get operation
+  public Item get(String tableName, Key key) throws RocksDBException {
+    byte[] keyBytes = key.toStorageKey().getBytes();
+    byte[] value =
+        transaction.get(new ReadOptions(), roxDB.getOrCreateColumnFamily(tableName), keyBytes);
+
+    if (value == null) {
+      logger.debug("Transaction {} item not found: {}", transaction.getID(), key.toStorageKey());
+      return null;
+    }
+
+    // Convert bytes to Map
+    Map<String, Object> attributes = SerDeUtils.deserializeAttributes(value);
+    Item item = new Item(key, attributes);
+    logger.debug("Transaction {} item found: {}", transaction.getID(), item.key().toStorageKey());
+    return item;
+  }
+}

--- a/src/main/java/com/github/lukaszbudnik/roxdb/rocksdb/TransactionOperations.java
+++ b/src/main/java/com/github/lukaszbudnik/roxdb/rocksdb/TransactionOperations.java
@@ -1,0 +1,8 @@
+package com.github.lukaszbudnik.roxdb.rocksdb;
+
+import org.rocksdb.RocksDBException;
+
+@FunctionalInterface
+public interface TransactionOperations {
+    void doInTransaction(TransactionContext transactionContext) throws RocksDBException;
+}

--- a/src/main/proto/roxdb.proto
+++ b/src/main/proto/roxdb.proto
@@ -27,6 +27,7 @@ message ItemRequest {
     GetItem get_item = 5;
     DeleteItem delete_item = 6;
     Query query = 7;
+    TransactWriteItems transact_write_items = 8;  // New operation
   }
 
   message PutItem {
@@ -55,23 +56,30 @@ message ItemRequest {
     optional string sort_key_start = 3;
     optional string sort_key_end = 4;
   }
+
+  message TransactWriteItems {
+    repeated TransactWriteItem items = 1;
+  }
+
+  message TransactWriteItem {
+    oneof operation {
+      PutItem put = 1;
+      UpdateItem update = 2;
+      DeleteItem delete = 3;
+    }
+  }
 }
 
 message ItemResponse {
   string correlation_id = 1;
   oneof result {
-    // Response to PutItem
-    PutItemResponse put_item_response = 2;
-    // Response to UpdateItem
-    UpdateItemResponse update_item_response = 3;
-    // Response to GetItem
-    GetItemResponse get_item_response = 4;
-    // Response to DeleteItem
-    DeleteItemResponse delete_item_response = 5;
-    // Response to Query
-    QueryResponse query_response = 6;
-    // Error
-    Error error = 7;
+    Error error = 2;
+    PutItemResponse put_item_response = 3;
+    UpdateItemResponse update_item_response = 4;
+    GetItemResponse get_item_response = 5;
+    DeleteItemResponse delete_item_response = 6;
+    QueryResponse query_response = 7;
+    TransactWriteItemsResponse transact_write_items_response = 8;
   }
 
   // Error structure
@@ -116,6 +124,16 @@ message ItemResponse {
   message DeleteItemResponse {
     oneof result {
       Key key = 1;
+    }
+  }
+
+  message TransactWriteItemsResponse {
+    oneof result {
+      TransactWriteItemsResult transact_write_items_result = 1;
+    }
+
+    message TransactWriteItemsResult {
+      repeated Key modified_keys = 1;
     }
   }
 


### PR DESCRIPTION
This pull request contains the following changes:

- RoxDB implementation is now using `TransactionDB`
- RoxDB gRPC service implements `TransactWriteItems` with `Put`, `Update`, and `Delete` operations
- Refactoring in RoxDB gRPC to make the code more readable and maintainable 