### PR TITLE
Query operation to support fine-grained control over sort keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,11 +105,11 @@ using AI-powered code generation tools like Amazon Q to streamline development.
    {
      "correlation_id": "123",
      "put_item": {
-       "table": "your-table-name",
+       "table": "users",
        "item": {
          "key": {
-           "partition_key": "part1",
-           "sort_key": "sort1"
+           "partition_key": "user#123",
+           "sort_key": "settings"
          },
          "attributes": {
            "field1": "value1",
@@ -119,13 +119,29 @@ using AI-powered code generation tools like Amazon Q to streamline development.
      }
    }
    {
-     "correlation_id": "124",
-     "update_item": {
-       "table": "your-table-name",
+     "correlation_id": "123",
+     "put_item": {
+       "table": "users",
        "item": {
          "key": {
-           "partition_key": "part1",
-           "sort_key": "sort1"
+           "partition_key": "user#123",
+           "sort_key": "address"
+         },
+         "attributes": {
+           "country": "Poland",
+           "city": "Wejherowo"
+         }
+       }
+     }
+   }
+   {
+     "correlation_id": "124",
+     "update_item": {
+       "table": "users",
+       "item": {
+         "key": {
+           "partition_key": "user#123",
+           "sort_key": "settings"
          },
          "attributes": {
            "field1": "new value for field1",
@@ -137,30 +153,66 @@ using AI-powered code generation tools like Amazon Q to streamline development.
    {
      "correlation_id": "125",
      "get_item": {
-       "table": "your-table-name",
+       "table": "users",
        "key": {
-         "partition_key": "part1",
-         "sort_key": "sort1"
+         "partition_key": "user#123",
+         "sort_key": "settings"
+       }
+     }
+   }
+   {
+     "correlation_id": "query-with-no-sort-key-range-1",
+     "query": {
+       "table": "users",
+       "partition_key": "user#123",
+       "limit": 10
+     }
+   }
+   {
+     "correlation_id": "query-with-sort-key-and-boundaries-1",
+     "query": {
+       "table": "users",
+       "partition_key": "user#123",
+       "limit": 10,
+       "sort_key_range": {
+         "start": {
+           "value": "address",
+           "type": "INCLUSIVE"
+         },
+         "end": {
+           "value": "settings",
+           "type": "EXCLUSIVE"
+         }
        }
      }
    }
    {
      "correlation_id": "126",
      "delete_item": {
-       "table": "your-table-name",
+       "table": "users",
        "key": {
-         "partition_key": "part1",
-         "sort_key": "sort1"
+         "partition_key": "user#123",
+         "sort_key": "settings"
        }
      }
    }
    {
      "correlation_id": "127",
-     "get_item": {
-       "table": "your-table-name",
+     "delete_item": {
+       "table": "users",
        "key": {
-         "partition_key": "part1",
-         "sort_key": "sort1"
+         "partition_key": "user#123",
+         "sort_key": "address"
+       }
+     }
+   }
+   {
+     "correlation_id": "128",
+     "get_item": {
+       "table": "users",
+       "key": {
+         "partition_key": "user#123",
+         "sort_key": "settings"
        }
      }
    }

--- a/src/main/java/com/github/lukaszbudnik/roxdb/rocksdb/RangeBoundary.java
+++ b/src/main/java/com/github/lukaszbudnik/roxdb/rocksdb/RangeBoundary.java
@@ -1,0 +1,11 @@
+package com.github.lukaszbudnik.roxdb.rocksdb;
+
+public record RangeBoundary(String value, RangeType type) {
+  public static RangeBoundary inclusive(String value) {
+    return new RangeBoundary(value, RangeType.INCLUSIVE);
+  }
+
+  public static RangeBoundary exclusive(String value) {
+    return new RangeBoundary(value, RangeType.EXCLUSIVE);
+  }
+}

--- a/src/main/java/com/github/lukaszbudnik/roxdb/rocksdb/RangeType.java
+++ b/src/main/java/com/github/lukaszbudnik/roxdb/rocksdb/RangeType.java
@@ -1,0 +1,6 @@
+package com.github.lukaszbudnik.roxdb.rocksdb;
+
+public enum RangeType {
+  INCLUSIVE,
+  EXCLUSIVE
+}

--- a/src/main/java/com/github/lukaszbudnik/roxdb/rocksdb/RoxDB.java
+++ b/src/main/java/com/github/lukaszbudnik/roxdb/rocksdb/RoxDB.java
@@ -16,10 +16,7 @@ public interface RoxDB extends AutoCloseable {
   Item getItem(String tableName, Key key) throws RocksDBException;
 
   List<Item> query(
-      String tableName,
-      String partitionKey,
-      Optional<String> sortKeyStart,
-      Optional<String> sortKeyEnd)
+      String tableName, String partitionKey, int limit, Optional<SortKeyRange> sortKeyRange)
       throws RocksDBException;
 
   void deleteItem(String tableName, Key key) throws RocksDBException;

--- a/src/main/java/com/github/lukaszbudnik/roxdb/rocksdb/SortKeyRange.java
+++ b/src/main/java/com/github/lukaszbudnik/roxdb/rocksdb/SortKeyRange.java
@@ -1,0 +1,17 @@
+package com.github.lukaszbudnik.roxdb.rocksdb;
+
+import java.util.Optional;
+
+public record SortKeyRange(Optional<RangeBoundary> start, Optional<RangeBoundary> end) {
+  public static SortKeyRange between(RangeBoundary start, RangeBoundary end) {
+    return new SortKeyRange(Optional.of(start), Optional.of(end));
+  }
+
+  public static SortKeyRange from(RangeBoundary start) {
+    return new SortKeyRange(Optional.of(start), Optional.empty());
+  }
+
+  public static SortKeyRange to(RangeBoundary end) {
+    return new SortKeyRange(Optional.empty(), Optional.of(end));
+  }
+}

--- a/src/main/proto/roxdb.proto
+++ b/src/main/proto/roxdb.proto
@@ -53,8 +53,23 @@ message ItemRequest {
   message Query {
     string table = 1;
     string partition_key = 2;
-    optional string sort_key_start = 3;
-    optional string sort_key_end = 4;
+    int32 limit = 3;
+    optional SortKeyRange sort_key_range = 4;
+  }
+
+  enum RangeType {
+    INCLUSIVE = 0;
+    EXCLUSIVE = 1;
+  }
+
+  message RangeBoundary {
+    string value = 1;
+    RangeType type = 2;
+  }
+
+  message SortKeyRange {
+    optional RangeBoundary start = 1;
+    optional RangeBoundary end = 2;
   }
 
   message TransactWriteItems {


### PR DESCRIPTION
The pull request contains the following changes:
- Refactored Query operation to support fine-grained control over sort keys, sort key start and sort key end can be both set to inclusive or exclusive (see unit tests for more details)
- New Query operation supports pagination of the results